### PR TITLE
Migrate to Official Python Atlas Client

### DIFF
--- a/rfcs/000-migration-official-atlas-client.md
+++ b/rfcs/000-migration-official-atlas-client.md
@@ -1,6 +1,6 @@
 - Feature Name: migrate_to_official_atlas_client
 - Start Date: 2020-11-09
-- RFC PR: [amundsen-io/rfcs#0000](https://github.com/amundsen-io/rfcs/pull/0000) (after opening the RFC PR, update this with a link to it and update the file name)
+- RFC PR: [amundsen-io/rfcs#17](https://github.com/amundsen-io/rfcs/pull/17) (after opening the RFC PR, update this with a link to it and update the file name)
 - Amundsen Issue: [amundsen-io/amundsen#0000](https://github.com/amundsen-io/amundsen/issues/0000) (leave this empty for now)
 
 # Migrate to Official Python Atlas Client

--- a/rfcs/000-migration-official-atlas-client.md
+++ b/rfcs/000-migration-official-atlas-client.md
@@ -1,0 +1,50 @@
+- Feature Name: migrate_to_official_atlas_client
+- Start Date: 2020-11-09
+- RFC PR: [amundsen-io/rfcs#0000](https://github.com/amundsen-io/rfcs/pull/0000) (after opening the RFC PR, update this with a link to it and update the file name)
+- Amundsen Issue: [amundsen-io/amundsen#0000](https://github.com/amundsen-io/amundsen/issues/0000) (leave this empty for now)
+
+# Migrate to Official Python Atlas Client
+
+## Summary
+
+For now, we are relying on a custom built [pyatlasclient](https://pyatlasclient.readthedocs.io/en/latest/index.html). Maintained by myself. 
+Atlas community recently launched an official version of python client [apache-atlas](https://pypi.org/project/apache-atlas/). 
+In an effort to keep using up to date features supported by the community, we should move to the official version.
+
+## Motivation
+
+The official version supports all the available APIs of Apache Atlas, which are missing in the client we are currently using. 
+
+## Guide-level Explanation (aka Product Details)
+
+NA
+
+## UI/UX-level Explanation
+
+NA
+
+## Reference-level Explanation (aka Technical Details)
+
+This new change will mean to be re-implementing the Atlas Proxy for both metadata and search service. 
+
+## Drawbacks
+
+The official version is written by java engineers as you can see the implementation, but instead of maintaining or fixing 
+our custom package, we can support the official version, and invest our time in improving that. 
+
+## Alternatives
+
+Keep using the existing pyatlasclient, but there is no other maintainer in that repo to help me out with adding new feature and maintaining the existing ones.
+
+## Prior art
+
+The official community recently launched this client, so we are not sure about the way of working for that project. 
+If we want to improve anything in that package, how long will it take etc.  
+
+## Unresolved questions
+
+NA
+
+## Future possibilities
+
+The official version will be maintained/fixed every time there is a new change in the Apache Atlas, hence will always be more up to date. 


### PR DESCRIPTION
Signed-off-by: verdan <verdan.mahmood@gmail.com>

Atlas community recently released an official python client to interact with Apache Atlas. For now, we are relying on our custom client, which does not have all the endpoints implemented yet. 